### PR TITLE
Global Exception Handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.4.5'
+  id 'org.springframework.boot' version '2.3.12.RELEASE'
   id 'org.owasp.dependencycheck' version '6.2.1'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.2.0'
+  id 'io.freefair.lombok' version '6.0.0-m2'
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -187,13 +188,10 @@ dependencies {
 
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.8.RELEASE'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.9.RELEASE'
 
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
   compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
-
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.6'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.6'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/demo/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/demo/controllers/GetWelcomeTest.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.demo.controllers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.reform.demo.errorhandling.ExceptionResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,4 +26,13 @@ public class GetWelcomeTest {
 
         assertThat(response.getResponse().getContentAsString()).startsWith("Welcome");
     }
+
+    @DisplayName("Should welcome upon root request with 404 response code")
+    @Test
+    public void publicationEndpoint() throws Exception {
+        MvcResult response = mockMvc.perform(get("/publication")).andExpect(status().isNotFound()).andReturn();
+
+        assertThat(response.getResponse().getContentAsString()).contains("Publication");
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/demo/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/demo/controllers/GetWelcomeTest.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.demo.controllers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import uk.gov.hmcts.reform.demo.errorhandling.ExceptionResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/main/java/uk/gov/hmcts/reform/demo/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/controllers/RootController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.demo.controllers;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.demo.errorhandling.exceptions.PublicationNotFoundException;
 
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -24,5 +25,15 @@ public class RootController {
     @GetMapping("/")
     public ResponseEntity<String> welcome() {
         return ok("Welcome to spring-boot-template");
+    }
+
+    /**
+     * Dummy endpoint, that demonstrates how the Global Exception handler can be used to capture
+     * and parse exceptions into a standard format.
+     * @return A ResponseEntity
+     */
+    @GetMapping("/publication")
+    public ResponseEntity<String> getPublications() {
+        throw new PublicationNotFoundException("Publication has not been found");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
@@ -1,15 +1,12 @@
 package uk.gov.hmcts.reform.demo.errorhandling;
 
-import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 /**
  * Exception Response class, to standardise exceptions returned from the server.
  */
-@Builder
 @Data
 public class ExceptionResponse {
 

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.demo.errorhandling;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Exception Response class, to standardise exceptions returned from the server.
+ */
+@Builder
+@Data
+public class ExceptionResponse {
+
+    /**
+     * The error message to return.
+     */
+    private String message;
+
+    /**
+     * The timestamp of when the error occurred.
+     */
+    private LocalDateTime timestamp;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
@@ -11,14 +11,14 @@ import java.time.LocalDateTime;
 
 /**
  * Global exception handler, that captures exceptions thrown by the controllers, and encapsulates
- * the logic to handle them and return a standardised response to the user
+ * the logic to handle them and return a standardised response to the user.
  */
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     /**
      * Template exception handler, that handles a custom PublicationNotFoundException,
-     * and returns a 404 in the standard format
+     * and returns a 404 in the standard format.
      * @param ex The exception that has been thrown.
      * @param request The request made to the endpoint.
      * @return The error response, modelled using the ExceptionResponse object.
@@ -26,10 +26,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PublicationNotFoundException.class)
     ResponseEntity<ExceptionResponse> handlePublicationNotFound(PublicationNotFoundException ex, WebRequest request) {
 
-        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-            .message(ex.getMessage())
-            .timestamp(LocalDateTime.now())
-            .build();
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
     }

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.demo.errorhandling;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.hmcts.reform.demo.errorhandling.exceptions.PublicationNotFoundException;
+
+import java.time.LocalDateTime;
+
+/**
+ * Global exception handler, that captures exceptions thrown by the controllers, and encapsulates
+ * the logic to handle them and return a standardised response to the user
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Template exception handler, that handles a custom PublicationNotFoundException,
+     * and returns a 404 in the standard format
+     * @param ex The exception that has been thrown.
+     * @param request The request made to the endpoint.
+     * @return The error response, modelled using the ExceptionResponse object.
+     */
+    @ExceptionHandler(PublicationNotFoundException.class)
+    ResponseEntity<ExceptionResponse> handlePublicationNotFound(PublicationNotFoundException ex, WebRequest request) {
+
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+            .message(ex.getMessage())
+            .timestamp(LocalDateTime.now())
+            .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/PublicationNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/PublicationNotFoundException.java
@@ -5,6 +5,8 @@ package uk.gov.hmcts.reform.demo.errorhandling.exceptions;
  */
 public class PublicationNotFoundException extends RuntimeException {
 
+    private static final long serialVersionUID = -2261417166948666798L;
+
     /**
      * Constructor for the Exception.
      * @param message The message to return to the end user

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/PublicationNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/PublicationNotFoundException.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.demo.errorhandling.exceptions;
+
+/**
+ * Exception that captures the message when a subscription is not found.
+ */
+public class PublicationNotFoundException extends RuntimeException {
+
+    /**
+     * Constructor for the Exception.
+     * @param message The message to return to the end user
+     */
+    public PublicationNotFoundException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-503

### Change description ###

This adds in an example of Global Exception handling to the repo, which we can use going forwards to handle exceptions, keeping the controllers and other classes free from needed to know how to deal with exceptions, what status codes to return in each scenario etc.

Example of it can be seen https://www.baeldung.com/exception-handling-for-rest-with-spring, in section 4.

To get the Spring Application to run, I've had to change the version of spring to 2.3.12.RELEASE for now. 2.4.5 doesn't seem to support Hystrix, which now seems to be deprecated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
