### PR TITLE
PUB-1316 Media user verification email

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -65,6 +65,7 @@ class NotifyTest {
     private static final String API_SUBSCRIPTION_URL = "/notify/api";
     private static final String EXTERNAL_PAYLOAD = "test";
     private static final String UNIDENTIFIED_BLOB_EMAIL_URL = "/notify/unidentified-blob";
+    private static final String MEDIA_VERIFICATION_EMAIL_URL = "/notify/media/verification";
     private static final UUID ID = UUID.randomUUID();
     private static final String ID_STRING = UUID.randomUUID().toString();
     private static final String FULL_NAME = "Test user";
@@ -127,6 +128,9 @@ class NotifyTest {
         + "    ]\n"
         + "  }\n"
         + "}";
+
+    private static final String VALID_MEDIA_VERIFICATION_EMAIL_BODY =
+        "{\"fullName\": \"fullName\", \"email\": \"test@email.com\"}";
 
     private static final List<MediaApplication> MEDIA_APPLICATION_LIST =
         List.of(new MediaApplication(ID, FULL_NAME, EMAIL, EMPLOYER,
@@ -466,6 +470,24 @@ class NotifyTest {
     @Test
     void testInvalidPayloadUnidentifiedBlobEmail() throws Exception {
         mockMvc.perform(post(UNIDENTIFIED_BLOB_EMAIL_URL)
+                            .content("invalid content")
+                            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testValidPayloadMediaVerificationEmail() throws Exception {
+        mockMvc.perform(post(MEDIA_VERIFICATION_EMAIL_URL)
+                            .content(VALID_MEDIA_VERIFICATION_EMAIL_BODY)
+                            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "Media user verification email successfully sent with referenceId")));
+    }
+
+    @Test
+    void testInvalidPayloadMediaVerificationEmail() throws Exception {
+        mockMvc.perform(post(MEDIA_VERIFICATION_EMAIL_URL)
                             .content("invalid content")
                             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest());

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationController.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.pip.publication.services.authentication.roles.IsAdmin
 import uk.gov.hmcts.reform.pip.publication.services.models.MediaApplication;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -172,4 +173,17 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.handleThirdParty(apiDestination));
     }
 
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "Media user verification email successfully sent with referenceId: {Id}"),
+        @ApiResponse(code = 400, message = BAD_PAYLOAD_ERROR_MESSAGE),
+        @ApiResponse(code = 400, message = NOTIFY_EXCEPTION_ERROR_MESSAGE)
+    })
+    @ApiOperation("Send a media user a verification email")
+    @PostMapping("/media/verification")
+    public ResponseEntity<String> sendMediaUserVerificationEmail(@RequestBody MediaVerificationEmail body) {
+        return ResponseEntity.ok(String.format(
+            "Media user verification email successfully sent with referenceId: %s",
+            notificationService.mediaUserVerificationEmailRequest(body)
+        ));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/PersonalisationLinks.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/PersonalisationLinks.java
@@ -10,4 +10,5 @@ public class PersonalisationLinks {
     private String govGuidancePageLink;
     private String aadSignInPageLink;
     private String aadPwResetLink;
+    private String mediaVerificationPageLink;
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/request/MediaVerificationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/request/MediaVerificationEmail.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.pip.publication.services.models.request;
+
+import lombok.Data;
+import lombok.Value;
+
+@Data
+@Value
+public class MediaVerificationEmail {
+    String fullName;
+    String email;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/notify/Templates.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/notify/Templates.java
@@ -12,7 +12,8 @@ public enum Templates {
     MEDIA_NEW_ACCOUNT_SETUP("e426073b-958c-42a2-a94f-bbdd1a400cb7"),
     MEDIA_DUPLICATE_ACCOUNT_EMAIL("13b058a5-82da-4331-98ff-97d3ebf66f51"),
     MEDIA_APPLICATION_REPORTING_EMAIL("c59c90a3-1806-4649-b4b5-b6bce8f8f72c"),
-    BAD_BLOB_EMAIL("0fbd150f-ff5b-49f0-aa34-6a6273901ceb");
+    BAD_BLOB_EMAIL("0fbd150f-ff5b-49f0-aa34-6a6273901ceb"),
+    MEDIA_USER_VERIFICATION_EMAIL("1dea6b4b-48b6-4eb1-8b86-7031de5502d9");
 
     public final String template;
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/EmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/EmailService.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.EmailToSend;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
 import uk.gov.service.notify.NotificationClientException;
@@ -69,6 +70,11 @@ public class EmailService {
         return generateEmail(piTeamEmail, template,
                              personalisationService
                                 .buildUnidentifiedBlobsPersonalisation(locationMap));
+    }
+
+    protected EmailToSend buildMediaUserVerificationEmail(MediaVerificationEmail body, String template) {
+        return generateEmail(body.getEmail(), template,
+                             personalisationService.buildMediaVerificationPersonalisation(body));
     }
 
     public EmailToSend generateEmail(String email, String template, Map<String, Object> personalisation) {

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationService.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Location;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -163,5 +164,18 @@ public class NotificationService {
         log.info(writeLog(thirdPartyService.handleDeleteThirdPartyCall(apiDestination, null, null)));
 
         return String.format(EMPTY_SUCCESS_MESSAGE, apiDestination);
+    }
+
+    /**
+     * This method handles the sending of the media user verification email.
+     *
+     * @param body The body of the media verification email.
+     * @return The ID that references the media user verification email.
+     */
+    public String mediaUserVerificationEmailRequest(MediaVerificationEmail body) {
+        EmailToSend email = emailService
+            .buildMediaUserVerificationEmail(body, Templates.MEDIA_USER_VERIFICATION_EMAIL.template);
+
+        return emailService.sendEmail(email).getReference().orElse(null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
@@ -219,7 +219,7 @@ public class PersonalisationService {
     public Map<String, Object> buildMediaVerificationPersonalisation(MediaVerificationEmail body) {
         Map<String, Object> personalisation = new ConcurrentHashMap<>();
         personalisation.put(FULL_NAME, body.getFullName());
-        personalisation.put(VERIFICATION_PAGE_LINK, "https://placeholder-link.com");
+        personalisation.put(VERIFICATION_PAGE_LINK, notifyConfigProperties.getLinks().getMediaVerificationPageLink());
         return personalisation;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Location;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionTypes;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -61,6 +62,7 @@ public class PersonalisationService {
     private static final String YES = "Yes";
     private static final String NO = "No";
     private static final String ARRAY_OF_IDS = "array_of_ids";
+    private static final String VERIFICATION_PAGE_LINK = "verification_page_link";
 
     /**
      * Handles the personalisation for the Welcome email.
@@ -205,6 +207,19 @@ public class PersonalisationService {
 
 
         personalisation.put(ARRAY_OF_IDS, listOfUnmatched);
+        return personalisation;
+    }
+
+    /**
+     * Handles the personalisation for the media verification email.
+     *
+     * @param body The body of the media verification email.
+     * @return The personalisation map for the media verification email.
+     */
+    public Map<String, Object> buildMediaVerificationPersonalisation(MediaVerificationEmail body) {
+        Map<String, Object> personalisation = new ConcurrentHashMap<>();
+        personalisation.put(FULL_NAME, body.getFullName());
+        personalisation.put(VERIFICATION_PAGE_LINK, "https://placeholder-link.com");
         return personalisation;
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,7 +69,7 @@ notify:
     aad-sign-in-page-link: ${NOTIFY_LINK_AAD_SIGNIN_LINK:https://pib2csbox.b2clogin.com/pib2csbox.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_SignInUserFlow&client_id=c7e6e2c6-c23c-48e8-b9f4-6bad25a95331&nonce=defau&redirect_uri=https%3A%2F%2Fpip-frontend.staging.platform.hmcts.net%2Flogin%2Freturn&scope=openid&response_type=id_token&prompt=login}
     gov-guidance-page-link: ${NOTIFY_LINK_GOV_GUIDANCE:https://www.gov.uk}
     aad-pw-reset-link: ${NOTIFY_LINK_AAD_RESET_PW_LINK:https://pib2csbox.b2clogin.com/pib2csbox.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_initial_user_set_pwd&client_id=c7e6e2c6-c23c-48e8-b9f4-6bad25a95331&nonce=defaultNonce&redirect_uri=https%3A%2F%2Fpip-frontend.staging.platform.hmcts.net%2Flogin%2Freturn&scope=openid&response_type=id_token&prompt=login}
-    media-verification-page-link: ${MEDIA_VERIFICATION_PAGE_LINK:https://www.gov.uk}
+    media-verification-page-link: ${MEDIA_VERIFICATION_PAGE_LINK:https://pip-frontend.staging.platform.hmcts.net/media-verification?p=B2C_1_SignInMediaVerification}
   pi-team-email: ${PI_TEAM_EMAIL:teamEmail@email.com}
 
 error-handling:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,6 +69,7 @@ notify:
     aad-sign-in-page-link: ${NOTIFY_LINK_AAD_SIGNIN_LINK:https://pib2csbox.b2clogin.com/pib2csbox.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_SignInUserFlow&client_id=c7e6e2c6-c23c-48e8-b9f4-6bad25a95331&nonce=defau&redirect_uri=https%3A%2F%2Fpip-frontend.staging.platform.hmcts.net%2Flogin%2Freturn&scope=openid&response_type=id_token&prompt=login}
     gov-guidance-page-link: ${NOTIFY_LINK_GOV_GUIDANCE:https://www.gov.uk}
     aad-pw-reset-link: ${NOTIFY_LINK_AAD_RESET_PW_LINK:https://pib2csbox.b2clogin.com/pib2csbox.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_initial_user_set_pwd&client_id=c7e6e2c6-c23c-48e8-b9f4-6bad25a95331&nonce=defaultNonce&redirect_uri=https%3A%2F%2Fpip-frontend.staging.platform.hmcts.net%2Flogin%2Freturn&scope=openid&response_type=id_token&prompt=login}
+    media-verification-page-link: ${MEDIA_VERIFICATION_PAGE_LINK:https://www.gov.uk}
   pi-team-email: ${PI_TEAM_EMAIL:teamEmail@email.com}
 
 error-handling:

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.pip.publication.services.models.MediaApplication;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -54,6 +55,7 @@ class NotificationControllerTest {
     private CreatedAdminWelcomeEmail createdAdminWelcomeEmailValidBody;
     private DuplicatedMediaEmail createMediaSetupEmail;
     private ThirdPartySubscription thirdPartySubscription = new ThirdPartySubscription();
+    private MediaVerificationEmail mediaVerificationEmail;
 
     @Mock
     private NotificationService notificationService;
@@ -71,6 +73,7 @@ class NotificationControllerTest {
                                                                  VALID_EMAIL, EMPLOYER,
                                                                  ID_STRING, IMAGE_NAME,
                                                                  DATE_TIME, STATUS, DATE_TIME));
+        mediaVerificationEmail = new MediaVerificationEmail(FULL_NAME, VALID_EMAIL);
 
         subscriptionEmail = new SubscriptionEmail();
         subscriptionEmail.setEmail("a@b.com");
@@ -97,6 +100,8 @@ class NotificationControllerTest {
         when(notificationService.handleMediaApplicationReportingRequest(validMediaApplicationList))
             .thenReturn(SUCCESS_ID);
         when(notificationService.unidentifiedBlobEmailRequest(testUnidentifiedBlobMap))
+            .thenReturn(SUCCESS_ID);
+        when(notificationService.mediaUserVerificationEmailRequest(mediaVerificationEmail))
             .thenReturn(SUCCESS_ID);
     }
 
@@ -200,5 +205,12 @@ class NotificationControllerTest {
     void testSendThirdPartySubscriptionEmptyList() {
         assertTrue(notificationController.sendThirdPartySubscription(TEST).getBody().contains(SUCCESS_ID),
                    MESSAGES_MATCH);
+    }
+
+    @Test
+    void testSendMediaVerificationEmailReturnsOk() {
+        assertEquals(HttpStatus.OK, notificationController
+                         .sendMediaUserVerificationEmail(mediaVerificationEmail).getStatusCode(),
+                     STATUS_CODES_MATCH);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/notify/TemplatesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/notify/TemplatesTest.java
@@ -12,6 +12,7 @@ class TemplatesTest {
     private static final String EXISTING_USER_WELCOME_TEMPLATE = "321cbaa6-2a19-4980-87c6-fe90516db59b";
     private static final String MEDIA_APPLICATION_REPORTING_EMAIL = "c59c90a3-1806-4649-b4b5-b6bce8f8f72c";
     private static final String BAD_BLOB_EMAIL = "0fbd150f-ff5b-49f0-aa34-6a6273901ceb";
+    private static final String MEDIA_VERIFICATION_EMAIL = "1dea6b4b-48b6-4eb1-8b86-7031de5502d9";
 
 
     @Test
@@ -35,6 +36,12 @@ class TemplatesTest {
     @Test
     void testGetBadBlobEmailTemplate() {
         assertEquals(BAD_BLOB_EMAIL, Templates.BAD_BLOB_EMAIL.template,
+                     SHOULD_MATCH_MESSAGE);
+    }
+
+    @Test
+    void testGetMediaVerificationTemplate() {
+        assertEquals(MEDIA_VERIFICATION_EMAIL, Templates.MEDIA_USER_VERIFICATION_EMAIL.template,
                      SHOULD_MATCH_MESSAGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/EmailServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.EmailToSend;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionTypes;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"PMD.TooManyMethods"})
 @SpringBootTest(classes = {Application.class, WebClientConfigurationTest.class})
 @ActiveProfiles("test")
 class EmailServiceTest {
@@ -255,6 +257,23 @@ class EmailServiceTest {
         assertEquals(personalisation, unidentifiedBlobEmail.getPersonalisation(),
                      PERSONALISATION_MESSAGE);
         assertEquals(Templates.BAD_BLOB_EMAIL.template, unidentifiedBlobEmail.getTemplate(),
+                     TEMPLATE_MESSAGE);
+    }
+
+    @Test
+    void testMediaVerificationEmailReturnsSuccess() {
+        MediaVerificationEmail mediaVerificationEmailData = new MediaVerificationEmail(FULL_NAME, EMAIL);
+        when(personalisationService.buildMediaVerificationPersonalisation(mediaVerificationEmailData))
+            .thenReturn(personalisation);
+
+        EmailToSend mediaVerificationEmail = emailService.buildMediaUserVerificationEmail(
+            mediaVerificationEmailData, Templates.MEDIA_USER_VERIFICATION_EMAIL.template);
+
+        assertEquals(EMAIL, mediaVerificationEmail.getEmailAddress(),
+                     GENERATED_EMAIL_MESSAGE);
+        assertEquals(personalisation, mediaVerificationEmail.getPersonalisation(),
+                     PERSONALISATION_MESSAGE);
+        assertEquals(Templates.MEDIA_USER_VERIFICATION_EMAIL.template, mediaVerificationEmail.getTemplate(),
                      TEMPLATE_MESSAGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Location;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionTypes;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
@@ -52,6 +53,9 @@ class NotificationServiceTest {
         EMAIL, false, FULL_NAME);
     private static final CreatedAdminWelcomeEmail VALID_BODY_AAD = new CreatedAdminWelcomeEmail(
         EMAIL, "test_forename", "test_surname");
+
+    private static final MediaVerificationEmail MEDIA_VERIFICATION_EMAIL = new MediaVerificationEmail(
+        EMAIL, FULL_NAME);
 
     private static final String TEST_EMAIL = "test@email.com";
     private static final String SUCCESS_REF_ID = "successRefId";
@@ -278,5 +282,15 @@ class NotificationServiceTest {
 
         assertEquals(EMPTY_API_SENT, notificationService.handleThirdParty(API_DESTINATION),
                      MESSAGES_MATCH);
+    }
+
+    @Test
+    void testValidPayloadReturnsSuccessMediaVerification() {
+        when(emailService.buildMediaUserVerificationEmail(MEDIA_VERIFICATION_EMAIL,
+                                                      Templates.MEDIA_USER_VERIFICATION_EMAIL.template))
+            .thenReturn(validEmailBodyForEmailClient);
+
+        assertEquals(SUCCESS_REF_ID, notificationService.mediaUserVerificationEmailRequest(MEDIA_VERIFICATION_EMAIL),
+                     "Media user verification email successfully sent with referenceId: referenceId.");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.external.ListType;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Location;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.MediaVerificationEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionTypes;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
@@ -62,6 +63,7 @@ class PersonalisationServiceTest {
     private static final String LOCATION_ID = "12345";
     private static final byte[] TEST_BYTE = "Test byte".getBytes();
     private static final String ARRAY_OF_IDS = "array_of_ids";
+    private static final String VERIFICATION_PAGE_LINK = "verification_page_link";
 
     @Autowired
     PersonalisationService personalisationService;
@@ -391,5 +393,20 @@ class PersonalisationServiceTest {
 
         assertEquals(expectedData, personalisation.get(ARRAY_OF_IDS),
                      "Locations map not as expected");
+    }
+
+    @Test
+    void testBuildMediaVerificationPersonalisation() {
+        MediaVerificationEmail mediaVerificationEmail = new MediaVerificationEmail(FULL_NAME, EMAIL);
+
+        Map<String, Object> personalisation = personalisationService
+            .buildMediaVerificationPersonalisation(mediaVerificationEmail);
+
+        Object fullNameObject = personalisation.get("full_name");
+        assertNotNull(fullNameObject, "No full name found");
+        assertEquals(fullNameObject, FULL_NAME, "Full name does not match");
+
+        Object mediaVerificationLink = personalisation.get(VERIFICATION_PAGE_LINK);
+        assertNotNull(mediaVerificationLink, "No media verification link key found");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
@@ -408,5 +408,8 @@ class PersonalisationServiceTest {
 
         Object mediaVerificationLink = personalisation.get(VERIFICATION_PAGE_LINK);
         assertNotNull(mediaVerificationLink, "No media verification link key found");
+        PersonalisationLinks personalisationLinks = notifyConfigProperties.getLinks();
+        assertEquals(personalisationLinks.getMediaVerificationPageLink(), mediaVerificationLink,
+                     "Media verification link does not match expected link");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1316

### Change description ###

Added new endpoint to send the media verification email. 

![Screenshot 2022-08-04 at 12 30 25](https://user-images.githubusercontent.com/23316525/182836708-fae944e6-1b56-4a57-9774-b8016a628470.png)

Note: A placeholder link has been included for now until the link up tickets are played.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
