### PR TITLE
PUB-1513 Send request header to third party API during deletion of publication

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.pip.publication.services.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.microsoft.applicationinsights.core.dependencies.google.common.collect.ImmutableMap;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -499,22 +498,21 @@ class NotifyTest {
             .andExpect(content()
                            .string(containsString("Successfully sent empty list to https://localhost:4444")));
 
-
         // Assert expected request headers sent to third party api
         RecordedRequest recordedRequest = externalApiMockServer.takeRequest();
-        Map<String, String> headers = ImmutableMap.<String, String>builder()
-            .put("x-provenance", "MANUAL_UPLOAD")
-            .put("x-type", "LIST")
-            .put("x-list-type", "CIVIL_DAILY_CAUSE_LIST")
-            .put("x-content-date", "2022-06-09T07:36:35")
-            .put("x-sensitivity", "PUBLIC")
-            .put("x-language", "ENGLISH")
-            .put("x-display-from", "2022-02-16T07:36:35")
-            .put("x-display-to", "2099-06-02T07:36:35")
-            .put("x-location-name", "Reading County Court and Family Court")
-            .put("x-location-jurisdiction", "Family,Civil")
-            .put("x-location-region", "South East")
-            .build();
+        Map<String, String> headers = Map.ofEntries(
+            Map.entry("x-provenance", "MANUAL_UPLOAD"),
+            Map.entry("x-type", "LIST"),
+            Map.entry("x-list-type", "CIVIL_DAILY_CAUSE_LIST"),
+            Map.entry("x-content-date", "2022-06-09T07:36:35"),
+            Map.entry("x-sensitivity", "PUBLIC"),
+            Map.entry("x-language", "ENGLISH"),
+            Map.entry("x-display-from", "2022-02-16T07:36:35"),
+            Map.entry("x-display-to", "2099-06-02T07:36:35"),
+            Map.entry("x-location-name", "Reading County Court and Family Court"),
+            Map.entry("x-location-jurisdiction", "Family,Civil"),
+            Map.entry("x-location-region", "South East")
+        );
 
         headers.entrySet().stream().forEach(e -> {
             assertThat(recordedRequest.getHeader(e.getKey()))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -67,6 +67,22 @@ class NotifyTest {
         "{\"apiDestination\": \"https://localhost:4444\", \"artefactId\": \"79f5c9ae-a951-44b5-8856-3ad6b7454b0e\"}";
     private static final String THIRD_PARTY_SUBSCRIPTION_INVALID_ARTEFACT_BODY =
         "{\"apiDestination\": \"http://localhost:4444\", \"artefactId\": \"1e565487-23e4-4a25-9364-43277a5180d4\"}";
+    private static final String THIRD_PARTY_SUBSCRIPTION_ARTEFACT_BODY = "{\n"
+        + "  \"apiDestination\": \"https://localhost:4444\",\n"
+        + "  \"artefact\": {\n"
+        + "    \"artefactId\": \"70494df0-31c1-4290-bbd2-7bfe7acfeb81\",\n"
+        + "    \"listType\": \"CIVIL_DAILY_CAUSE_LIST\",\n"
+        + "    \"locationId\": \"14\",\n"
+        + "    \"provenance\": \"MANUAL_UPLOAD\",\n"
+        + "    \"type\": \"LIST\",\n"
+        + "    \"contentDate\": \"2022-06-09T07:36:35\",\n"
+        + "    \"sensitivity\": \"PUBLIC\",\n"
+        + "    \"language\": \"ENGLISH\",\n"
+        + "    \"displayFrom\": \"2022-02-16T07:36:35\",\n"
+        + "    \"displayTo\": \"2099-06-02T07:36:35\"\n"
+        + "  }\n"
+        + "}";
+
     private static final String API_SUBSCRIPTION_URL = "/notify/api";
     private static final String EXTERNAL_PAYLOAD = "test";
     private static final String UNIDENTIFIED_BLOB_EMAIL_URL = "/notify/unidentified-blob";
@@ -78,7 +94,6 @@ class NotifyTest {
     private static final String STATUS = "APPROVED";
     private static final LocalDateTime DATE_TIME = LocalDateTime.now();
     private static final String IMAGE_NAME = "test-image.png";
-    private static final String VALID_API_DESTINATION = "https://localhost:4444";
     public static final String SUBS_EMAIL_SUCCESS = "Subscription email successfully sent to";
 
     private static final String NEW_LINE_WITH_BRACKET = "{\n";
@@ -478,7 +493,7 @@ class NotifyTest {
                                           .setResponseCode(200));
 
         mockMvc.perform(put(API_SUBSCRIPTION_URL)
-                            .content(VALID_API_DESTINATION)
+                            .content(THIRD_PARTY_SUBSCRIPTION_ARTEFACT_BODY)
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
             .andExpect(content()
                            .string(containsString("Successfully sent empty list to https://localhost:4444")));

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationController.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminW
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.service.NotificationService;
 
@@ -168,8 +169,7 @@ public class NotificationController {
     })
     @ApiOperation("Send empty list to third party after being deleted from P&I")
     @PutMapping("/api")
-    public ResponseEntity<String> sendThirdPartySubscription(@RequestBody String apiDestination) {
-        return ResponseEntity.ok(notificationService.handleThirdParty(apiDestination));
+    public ResponseEntity<String> sendThirdPartySubscription(@Valid @RequestBody ThirdPartySubscriptionArtefact body) {
+        return ResponseEntity.ok(notificationService.handleThirdParty(body));
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/request/ThirdPartySubscriptionArtefact.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/request/ThirdPartySubscriptionArtefact.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.pip.publication.services.models.request;
+
+import lombok.Data;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ThirdPartySubscriptionArtefact {
+    @NotNull
+    String apiDestination;
+
+    @NotNull
+    Artefact artefact;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminW
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.notify.Templates;
 
@@ -32,6 +33,7 @@ public class NotificationService {
 
     @Autowired
     private CsvCreationService csvCreationService;
+
     @Autowired
     private DataManagementService dataManagementService;
 
@@ -87,6 +89,7 @@ public class NotificationService {
 
     /**
      * This method handles the sending of the subscription email, and forwarding on to the relevant email client.
+     *
      * @param body The subscription message that is to be fulfilled.
      * @return The ID that references the subscription message.
      */
@@ -137,6 +140,7 @@ public class NotificationService {
     /**
      * Handles the incoming request for sending lists out to third party publishers, uses the artefact id from body
      * to retrieve Artefact from Data Management and then gets the file or json payload to then send out.
+     *
      * @param body Request body of ThirdParty subscription containing artefact id and the destination api.
      * @return String of successful POST.
      */
@@ -157,11 +161,21 @@ public class NotificationService {
         return String.format(SUCCESS_MESSAGE, body.getApiDestination());
     }
 
-    public String handleThirdParty(String apiDestination) {
+    /**
+     * Handles the incoming request for sending out an empty list to third party API with the deleted artefact
+     * information in the request headers.
+     *
+     * @param body Request body of ThirdParty subscription containing the deleted artefact and the destination api.
+     * @return String of successful PUT.
+     */
+    public String handleThirdParty(ThirdPartySubscriptionArtefact body) {
+        Artefact artefact = body.getArtefact();
+        Location location = dataManagementService.getLocation(artefact.getLocationId());
 
         log.info(writeLog("Sending blank payload to third party"));
-        log.info(writeLog(thirdPartyService.handleDeleteThirdPartyCall(apiDestination, null, null)));
-
-        return String.format(EMPTY_SUCCESS_MESSAGE, apiDestination);
+        log.info(writeLog(thirdPartyService.handleDeleteThirdPartyCall(body.getApiDestination(),
+                                                                       artefact,
+                                                                       location)));
+        return String.format(EMPTY_SUCCESS_MESSAGE, body.getApiDestination());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotificationControllerTest.java
@@ -9,10 +9,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.pip.publication.services.models.MediaApplication;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.CreatedAdminWelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMediaEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.service.NotificationService;
 
@@ -54,6 +56,7 @@ class NotificationControllerTest {
     private CreatedAdminWelcomeEmail createdAdminWelcomeEmailValidBody;
     private DuplicatedMediaEmail createMediaSetupEmail;
     private ThirdPartySubscription thirdPartySubscription = new ThirdPartySubscription();
+    private ThirdPartySubscriptionArtefact thirdPartySubscriptionArtefact = new ThirdPartySubscriptionArtefact();
 
     @Mock
     private NotificationService notificationService;
@@ -67,6 +70,8 @@ class NotificationControllerTest {
         createdAdminWelcomeEmailValidBody = new CreatedAdminWelcomeEmail(VALID_EMAIL, TEST, TEST);
         thirdPartySubscription.setApiDestination(TEST);
         thirdPartySubscription.setArtefactId(ID);
+        thirdPartySubscriptionArtefact.setApiDestination(TEST);
+        thirdPartySubscriptionArtefact.setArtefact(new Artefact());
         validMediaApplicationList = List.of(new MediaApplication(ID, FULL_NAME,
                                                                  VALID_EMAIL, EMPLOYER,
                                                                  ID_STRING, IMAGE_NAME,
@@ -93,7 +98,7 @@ class NotificationControllerTest {
         when(notificationService.azureNewUserEmailRequest(createdAdminWelcomeEmailValidBody)).thenReturn(SUCCESS_ID);
         when(notificationService.handleThirdParty(thirdPartySubscription)).thenReturn(SUCCESS_ID);
         when(notificationService.mediaDuplicateUserEmailRequest(createMediaSetupEmail)).thenReturn(SUCCESS_ID);
-        when(notificationService.handleThirdParty(TEST)).thenReturn(SUCCESS_ID);
+        when(notificationService.handleThirdParty(thirdPartySubscriptionArtefact)).thenReturn(SUCCESS_ID);
         when(notificationService.handleMediaApplicationReportingRequest(validMediaApplicationList))
             .thenReturn(SUCCESS_ID);
         when(notificationService.unidentifiedBlobEmailRequest(testUnidentifiedBlobMap))
@@ -192,13 +197,14 @@ class NotificationControllerTest {
 
     @Test
     void testSendThirdPartySubscriptionEmptyListReturnsOk() {
-        assertEquals(HttpStatus.OK, notificationController.sendThirdPartySubscription(TEST).getStatusCode(),
+        assertEquals(HttpStatus.OK,
+                     notificationController.sendThirdPartySubscription(thirdPartySubscriptionArtefact).getStatusCode(),
                      STATUS_CODES_MATCH);
     }
 
     @Test
     void testSendThirdPartySubscriptionEmptyList() {
-        assertTrue(notificationController.sendThirdPartySubscription(TEST).getBody().contains(SUCCESS_ID),
-                   MESSAGES_MATCH);
+        assertTrue(notificationController.sendThirdPartySubscription(thirdPartySubscriptionArtefact).getBody()
+                       .contains(SUCCESS_ID), MESSAGES_MATCH);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/NotificationServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.pip.publication.services.models.request.DuplicatedMed
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionEmail;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.SubscriptionTypes;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.publication.services.models.request.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.request.WelcomeEmail;
 import uk.gov.hmcts.reform.pip.publication.services.notify.Templates;
 import uk.gov.service.notify.SendEmailResponse;
@@ -276,7 +277,11 @@ class NotificationServiceTest {
         when(thirdPartyService.handleDeleteThirdPartyCall(API_DESTINATION, artefact, location))
             .thenReturn(SUCCESS_REF_ID);
 
-        assertEquals(EMPTY_API_SENT, notificationService.handleThirdParty(API_DESTINATION),
+        ThirdPartySubscriptionArtefact subscription = new ThirdPartySubscriptionArtefact();
+        subscription.setArtefact(artefact);
+        subscription.setApiDestination(API_DESTINATION);
+
+        assertEquals(EMPTY_API_SENT, notificationService.handleThirdParty(subscription),
                      MESSAGES_MATCH);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1513

### Change description ###

Send request headers containing the artefact information to a third party API during deletion of publications.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
