### PR TITLE
SJP press list header width update for publication date

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,11 @@ dependencies {
   implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
   implementation group: 'com.opencsv', name: 'opencsv', version: '5.5.2'
 
+  // Force upgrade snakeyaml version for CVE-2022-25857
+  implementation( group: 'org.yaml', name: 'snakeyaml').version {
+    strictly("1.31")
+  }
+
   testImplementation group: 'org.springframework.security', name: 'spring-security-test'
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/src/main/resources/templates/sjpPressList.html
+++ b/src/main/resources/templates/sjpPressList.html
@@ -81,7 +81,7 @@
     .mainHeaderText {
       font-family: "GDS Transport";
       display: inline-block;
-      width: 485px;
+      width: 475px;
       text-align: center;
       vertical-align: top;
     }

--- a/src/main/resources/templates/sjpPressList.html
+++ b/src/main/resources/templates/sjpPressList.html
@@ -81,7 +81,7 @@
     .mainHeaderText {
       font-family: "GDS Transport";
       display: inline-block;
-      width: 480px;
+      width: 485px;
       text-align: center;
       vertical-align: top;
     }

--- a/src/main/resources/templates/sjpPressList.html
+++ b/src/main/resources/templates/sjpPressList.html
@@ -70,7 +70,7 @@
     .logoDatesContainer {
       vertical-align: middle;
       display: inline-block;
-      width: 165px;
+      width: 190px;
     }
 
     .logoHeaderWrapper {
@@ -81,7 +81,7 @@
     .mainHeaderText {
       font-family: "GDS Transport";
       display: inline-block;
-      width: 500px;
+      width: 480px;
       text-align: center;
       vertical-align: top;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1500

### Change description ###

SJP press list header width update for publication date

<img width="759" alt="image" src="https://user-images.githubusercontent.com/80688761/188132379-13a27538-f519-4d0e-b60a-ec1ab38d0caf.png">


<img width="759" alt="image" src="https://user-images.githubusercontent.com/80688761/188132100-1aff7135-e6ad-4ae8-b7f5-1b3b0bfb05ae.png">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
