### PR TITLE
Force upgrade snakeyaml version for CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,11 @@ dependencies {
   implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
   implementation group: 'com.opencsv', name: 'opencsv', version: '5.5.2'
 
+  // Force upgrade snakeyaml version for CVE-2022-25857
+  implementation( group: 'org.yaml', name: 'snakeyaml').version {
+    strictly("1.31")
+  }
+
   testImplementation group: 'org.springframework.security', name: 'spring-security-test'
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -112,7 +112,7 @@ class NotifyTest {
         + SUBSCRIPTION_REQUEST;
 
     private static final String VALID_CIVIL_CAUSE_LIST_SUBS_EMAIL = "{\n"
-        + "  \"artefactId\": \"82c33285-ab4b-4c8e-8a80-b9ea7dc67db8\",\n"
+        + "  \"artefactId\": \"4d1e88f5-8457-4d93-8d11-1744a4bc16bd\",\n"
         + "  \"email\": \"test_account_admin@justice.gov.uk\",\n"
         + "  \"subscriptions\": {\n"
         + "    \"LOCATION_ID\": [\n"
@@ -122,7 +122,7 @@ class NotifyTest {
         + "}";
 
     private static final String VALID_FAMILY_CAUSE_LIST_SUBS_EMAIL = NEW_LINE_WITH_BRACKET
-        + "  \"artefactId\": \"55b9e27b-d315-4c7e-9116-0b83939c03eb\",\n"
+        + "  \"artefactId\": \"f94f0d2d-27e6-46f1-8528-e33eeac5728d\",\n"
         + "  \"email\": \"test_account_admin@justice.gov.uk\",\n"
         + SUBSCRIPTION_REQUEST;
 
@@ -132,7 +132,7 @@ class NotifyTest {
         + SUBSCRIPTION_REQUEST;
 
     private static final String VALID_SJP_PUBLIC_SUBS_EMAIL = NEW_LINE_WITH_BRACKET
-        + "  \"artefactId\": \"e61a7e34-f950-4a6c-9200-7b94745b5a7a\",\n"
+        + "  \"artefactId\": \"210c4598-7ec3-4a59-9b9a-d7ecf2197a40\",\n"
         + "  \"email\": \"test_account_admin@justice.gov.uk\",\n"
         + SUBSCRIPTION_REQUEST;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://nvd.nist.gov/vuln/detail/CVE-2022-25857

### Change description ###

Force upgrade snakeyaml version for CVE-2022-25857

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
