### PR TITLE
PUB-1295 - Added case names to email

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -97,7 +97,7 @@ class NotifyTest {
     private static final String THIRD_PARTY_SUBSCRIPTION_FILE_BODY = """
         {
             "apiDestination": "https://localhost:4444",
-            "artefactId": "0d838c30-fbde-449a-9f1b-6d5a306193b"
+            "artefactId": "0d838c30-fbde-449a-9f1b-6d5a306193b4"
         }
         """;
     private static final String THIRD_PARTY_SUBSCRIPTION_INVALID_ARTEFACT_BODY = """
@@ -484,7 +484,7 @@ class NotifyTest {
     void testValidFlatFileRequest() throws Exception {
         String validBody =
             "{\"email\":\"test_account_admin@justice.gov.uk\",\"subscriptions\": {\"LOCATION_ID\":[\"999\"]},"
-                + "\"artefactId\": \"0d838c30-fbde-449a-9f1b-6d5a306193b\"}";
+                + "\"artefactId\": \"0d838c30-fbde-449a-9f1b-6d5a306193b4\"}";
 
         mockMvc.perform(post(SUBSCRIPTION_URL)
                             .content(validBody)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -97,7 +97,7 @@ class NotifyTest {
     private static final String THIRD_PARTY_SUBSCRIPTION_FILE_BODY = """
         {
             "apiDestination": "https://localhost:4444",
-            "artefactId": "39f915df-c045-44d2-9692-778baa326cd0"
+            "artefactId": "6373f45-e980-444b-a9c8-7bfa3661be1f"
         }
         """;
     private static final String THIRD_PARTY_SUBSCRIPTION_INVALID_ARTEFACT_BODY = """
@@ -484,7 +484,7 @@ class NotifyTest {
     void testValidFlatFileRequest() throws Exception {
         String validBody =
             "{\"email\":\"test_account_admin@justice.gov.uk\",\"subscriptions\": {\"LOCATION_ID\":[\"999\"]},"
-                + "\"artefactId\": \"39f915df-c045-44d2-9692-778baa326cd0\"}";
+                + "\"artefactId\": \"96373f45-e980-444b-a9c8-7bfa3661be1f\"}";
 
         mockMvc.perform(post(SUBSCRIPTION_URL)
                             .content(validBody)
@@ -496,7 +496,7 @@ class NotifyTest {
     void testValidFlatFileRequestCsv() throws Exception {
         String validBody =
             "{\"email\":\"test_account_admin@justice.gov.uk\",\"subscriptions\": {\"LOCATION_ID\":[\"999\"]},"
-                + "\"artefactId\": \"494fa385-bbe6-4829-9998-07d19e903df2\"}";
+                + "\"artefactId\": \"83dcce68-ecea-402c-87cb-8066f3aefe13\"}";
 
         mockMvc.perform(post(SUBSCRIPTION_URL)
                             .content(validBody)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/publication/services/controllers/NotifyTest.java
@@ -97,7 +97,7 @@ class NotifyTest {
     private static final String THIRD_PARTY_SUBSCRIPTION_FILE_BODY = """
         {
             "apiDestination": "https://localhost:4444",
-            "artefactId": "6373f45-e980-444b-a9c8-7bfa3661be1f"
+            "artefactId": "0d838c30-fbde-449a-9f1b-6d5a306193b"
         }
         """;
     private static final String THIRD_PARTY_SUBSCRIPTION_INVALID_ARTEFACT_BODY = """
@@ -484,7 +484,7 @@ class NotifyTest {
     void testValidFlatFileRequest() throws Exception {
         String validBody =
             "{\"email\":\"test_account_admin@justice.gov.uk\",\"subscriptions\": {\"LOCATION_ID\":[\"999\"]},"
-                + "\"artefactId\": \"96373f45-e980-444b-a9c8-7bfa3661be1f\"}";
+                + "\"artefactId\": \"0d838c30-fbde-449a-9f1b-6d5a306193b\"}";
 
         mockMvc.perform(post(SUBSCRIPTION_URL)
                             .content(validBody)

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelper.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.pip.publication.services.helpers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.applicationinsights.core.dependencies.google.common.base.Strings;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.CaseSearch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Helper class for handling case names.
+ */
+@Component
+public final class CaseNameHelper {
+
+    private ObjectMapper objectMapper;
+
+    public CaseNameHelper() {
+        objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Extracts the associated case name to a case number.
+     * @param artefact The artefact to extract the case name from.
+     * @param content The case numbers that have been searched by.
+     * @return The list of case numbers, and case names if available.
+     */
+    public List<String> generateCaseNumberPersonalisation(Artefact artefact, List<String> content) {
+        if (artefact.getSearch() != null && artefact.getSearch().containsKey("cases")) {
+            List<CaseSearch> caseSearches = objectMapper.convertValue(artefact.getSearch().get("cases"),
+                                                                      new TypeReference<>() {});
+
+            List<String> contentWithCaseNames = new ArrayList<>();
+
+            content.forEach(caseNumber -> {
+                Optional<String> caseName = caseSearches.stream()
+                    .filter(caseSearch -> !Strings.isNullOrEmpty(caseSearch.getCaseNumber()))
+                    .filter(caseSearch -> caseSearch.getCaseNumber().equals(caseNumber))
+                    .map(CaseSearch::getCaseName)
+                    .filter(name -> !Strings.isNullOrEmpty(name))
+                    .findFirst();
+
+                if (caseName.isPresent()) {
+                    contentWithCaseNames.add(String.format("%s (%s)", caseNumber, caseName.get()));
+                } else {
+                    contentWithCaseNames.add(caseNumber);
+                }
+            });
+
+            return contentWithCaseNames;
+        }
+
+        return content;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/Artefact.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/Artefact.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.pip.publication.services.models.external;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -66,6 +68,11 @@ public class Artefact {
      * Language of publication.
      */
     private Language language;
+
+    /**
+     * Metadata that will be indexed for searching.
+     */
+    private Map<String, List<Object>> search;
 
     /**
      * Date / Time from which the publication will be displayed.

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/CaseSearch.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/CaseSearch.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.pip.publication.services.models.external;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * This model captures the case search details that are extracted from the blob.
+ * This can then be used in the subscriptions email, mapping case number to case name.
+ */
 @Getter
 @Setter
 public class CaseSearch {

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/CaseSearch.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/models/external/CaseSearch.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.pip.publication.services.models.external;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CaseSearch {
+
+    private String caseNumber;
+    private String caseName;
+    private String caseUrn;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationService.java
@@ -334,9 +334,6 @@ public class PersonalisationService {
         }
     }
 
-
-
-
     /**
      * Handles the personalisation for the duplicate media account email.
      *

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelperTest.java
@@ -4,12 +4,9 @@ import org.assertj.core.util.Strings;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.CaseSearch;
-import uk.gov.hmcts.reform.pip.publication.services.models.external.ListType;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,10 +20,15 @@ class CaseNameHelperTest {
 
     private CaseNameHelper caseNameHelper = new CaseNameHelper();
 
-
     @Test
     void testWithSearchNull() {
-        assertCaseNamePersonalisationIsCorrect(null, CASES, null);
+        Artefact artefact = new Artefact();
+        artefact.setSearch(null);
+
+        List<String> returnedCaseNumbers =
+            caseNameHelper.generateCaseNumberPersonalisation(artefact, List.of(CASE_NUMBER_VALUE));
+
+        assertEquals(List.of(CASE_NUMBER_VALUE), returnedCaseNumbers, "Case number not as expected");
     }
 
     @Test
@@ -77,10 +79,7 @@ class CaseNameHelperTest {
         searchCriteria.put(caseValue, List.of(caseSearch));
 
         Artefact artefact = new Artefact();
-        artefact.setArtefactId(UUID.randomUUID());
-        artefact.setContentDate(LocalDateTime.now());
         artefact.setSearch(searchCriteria);
-        artefact.setListType(ListType.SJP_PUBLIC_LIST);
 
         List<String> returnedCaseNumbers =
             caseNameHelper.generateCaseNumberPersonalisation(artefact, List.of(CASE_NUMBER_VALUE));

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/helpers/CaseNameHelperTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.reform.pip.publication.services.helpers;
+
+import org.assertj.core.util.Strings;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.CaseSearch;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.ListType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CaseNameHelperTest {
+
+    private static final String CASE_NUMBER_VALUE = "12345678";
+    private static final String CASE_NAME_VALUE = "This is a case name";
+
+    private static final String CASES = "cases";
+
+    private CaseNameHelper caseNameHelper = new CaseNameHelper();
+
+
+    @Test
+    void testWithSearchNull() {
+        assertCaseNamePersonalisationIsCorrect(null, CASES, null);
+    }
+
+    @Test
+    void testWithCaseNamePresent() {
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseName(CASE_NAME_VALUE);
+        caseSearch.setCaseNumber(CASE_NUMBER_VALUE);
+
+        assertCaseNamePersonalisationIsCorrect(caseSearch, CASES, CASE_NAME_VALUE);
+    }
+
+    @Test
+    void testWithSearchPresentButNoCaseName() {
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseNumber(CASE_NUMBER_VALUE);
+
+        assertCaseNamePersonalisationIsCorrect(caseSearch, CASES, null);
+    }
+
+    @Test
+    void testWithSearchPresentButDoesNotContainCases() {
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseName(CASE_NAME_VALUE);
+
+        assertCaseNamePersonalisationIsCorrect(caseSearch, "cases2", null);
+    }
+
+    @Test
+    void testWithCaseNumberPresentButIsEmpty() {
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseNumber("");
+        caseSearch.setCaseName(CASE_NAME_VALUE);
+
+        assertCaseNamePersonalisationIsCorrect(caseSearch, CASES, null);
+    }
+
+    @Test
+    void testWithCaseNumberPresentButDoesNotMatch() {
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseNumber("11111111");
+        caseSearch.setCaseName(CASE_NAME_VALUE);
+
+        assertCaseNamePersonalisationIsCorrect(caseSearch, CASES, null);
+    }
+
+    private void assertCaseNamePersonalisationIsCorrect(CaseSearch caseSearch, String caseValue, String caseName) {
+        Map<String, List<Object>> searchCriteria = new ConcurrentHashMap<>();
+        searchCriteria.put(caseValue, List.of(caseSearch));
+
+        Artefact artefact = new Artefact();
+        artefact.setArtefactId(UUID.randomUUID());
+        artefact.setContentDate(LocalDateTime.now());
+        artefact.setSearch(searchCriteria);
+        artefact.setListType(ListType.SJP_PUBLIC_LIST);
+
+        List<String> returnedCaseNumbers =
+            caseNameHelper.generateCaseNumberPersonalisation(artefact, List.of(CASE_NUMBER_VALUE));
+
+        if (Strings.isNullOrEmpty(caseName)) {
+            assertEquals(List.of(CASE_NUMBER_VALUE), returnedCaseNumbers, "Case number not as expected");
+        } else {
+            assertEquals(List.of(CASE_NUMBER_VALUE + " (" + CASE_NAME_VALUE + ")"), returnedCaseNumbers,
+                         "Case number not as expected");
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/PersonalisationServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.pip.publication.services.errorhandling.exceptions.Not
 import uk.gov.hmcts.reform.pip.publication.services.models.NoMatchArtefact;
 import uk.gov.hmcts.reform.pip.publication.services.models.PersonalisationLinks;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Artefact;
+import uk.gov.hmcts.reform.pip.publication.services.models.external.CaseSearch;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.FileType;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.ListType;
 import uk.gov.hmcts.reform.pip.publication.services.models.external.Location;
@@ -36,6 +37,7 @@ import uk.gov.service.notify.NotificationClientException;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -248,6 +250,116 @@ class PersonalisationServiceTest {
 
         Object contentDate = personalisation.get(CONTENT_DATE);
         assertNotNull(contentDate, CONTENT_DATE_ASSERT_MESSAGE);
+    }
+
+    @Test
+    void buildRawDataWithCaseNamePresent() {
+        Map<String, List<Object>> searchCriteria = new HashMap<>();
+
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseName("This is a case name");
+        caseSearch.setCaseNumber(CASE_NUMBER_VALUE);
+
+        searchCriteria.put("cases", List.of(caseSearch));
+
+        Artefact artefact = new Artefact();
+        artefact.setArtefactId(UUID.randomUUID());
+        artefact.setContentDate(LocalDateTime.now());
+        artefact.setSearch(searchCriteria);
+        artefact.setListType(ListType.SJP_PUBLIC_LIST);
+        when(dataManagementService.getLocation(LOCATION_ID)).thenReturn(location);
+        when(channelManagementService.getArtefactSummary(any())).thenReturn(HELLO);
+        when(channelManagementService.getArtefactFiles(any())).thenReturn(FILES_MAP);
+
+        Map<String, Object> personalisation =
+            personalisationService.buildRawDataSubscriptionPersonalisation(SUBSCRIPTIONS_EMAIL, artefact);
+
+        assertEquals(YES, personalisation.get(DISPLAY_CASE_NUMBERS), "Display case numbers is not Yes");
+        assertEquals(List.of(CASE_NUMBER_VALUE + " (This is a case name)"), personalisation.get(CASE_NUMBERS),
+                     "Case number not as expected"
+        );
+    }
+
+    @Test
+    void buildRawDataWithSearchPresentButNoCaseName() {
+        Map<String, List<Object>> searchCriteria = new HashMap<>();
+
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseName("This is a case name");
+
+        searchCriteria.put("cases", List.of(caseSearch));
+
+        Artefact artefact = new Artefact();
+        artefact.setArtefactId(UUID.randomUUID());
+        artefact.setContentDate(LocalDateTime.now());
+        artefact.setSearch(searchCriteria);
+        artefact.setListType(ListType.SJP_PUBLIC_LIST);
+        when(dataManagementService.getLocation(LOCATION_ID)).thenReturn(location);
+        when(channelManagementService.getArtefactSummary(any())).thenReturn(HELLO);
+        when(channelManagementService.getArtefactFiles(any())).thenReturn(FILES_MAP);
+
+        Map<String, Object> personalisation =
+            personalisationService.buildRawDataSubscriptionPersonalisation(SUBSCRIPTIONS_EMAIL, artefact);
+
+        assertEquals(YES, personalisation.get(DISPLAY_CASE_NUMBERS), "Display case numbers is not Yes");
+        assertEquals(List.of(CASE_NUMBER_VALUE), personalisation.get(CASE_NUMBERS),
+                     "Case number not as expected"
+        );
+    }
+
+    @Test
+    void buildRawDataWithSearchPresentButDoesNotContainCases() {
+        Map<String, List<Object>> searchCriteria = new HashMap<>();
+
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseName("This is a case name");
+
+        searchCriteria.put("cases2", List.of(caseSearch));
+
+        Artefact artefact = new Artefact();
+        artefact.setArtefactId(UUID.randomUUID());
+        artefact.setContentDate(LocalDateTime.now());
+        artefact.setSearch(searchCriteria);
+        artefact.setListType(ListType.SJP_PUBLIC_LIST);
+        when(dataManagementService.getLocation(LOCATION_ID)).thenReturn(location);
+        when(channelManagementService.getArtefactSummary(any())).thenReturn(HELLO);
+        when(channelManagementService.getArtefactFiles(any())).thenReturn(FILES_MAP);
+
+        Map<String, Object> personalisation =
+            personalisationService.buildRawDataSubscriptionPersonalisation(SUBSCRIPTIONS_EMAIL, artefact);
+
+        assertEquals(YES, personalisation.get(DISPLAY_CASE_NUMBERS), "Display case numbers is not Yes");
+        assertEquals(List.of(CASE_NUMBER_VALUE), personalisation.get(CASE_NUMBERS),
+                     "Case number not as expected"
+        );
+    }
+
+    @Test
+    void buildRawDataWithCaseNumberPresentButIsEmpty() {
+        Map<String, List<Object>> searchCriteria = new HashMap<>();
+
+        CaseSearch caseSearch = new CaseSearch();
+        caseSearch.setCaseNumber("");
+        caseSearch.setCaseName("This is a case name");
+
+        searchCriteria.put("cases2", List.of(caseSearch));
+
+        Artefact artefact = new Artefact();
+        artefact.setArtefactId(UUID.randomUUID());
+        artefact.setContentDate(LocalDateTime.now());
+        artefact.setSearch(searchCriteria);
+        artefact.setListType(ListType.SJP_PUBLIC_LIST);
+        when(dataManagementService.getLocation(LOCATION_ID)).thenReturn(location);
+        when(channelManagementService.getArtefactSummary(any())).thenReturn(HELLO);
+        when(channelManagementService.getArtefactFiles(any())).thenReturn(FILES_MAP);
+
+        Map<String, Object> personalisation =
+            personalisationService.buildRawDataSubscriptionPersonalisation(SUBSCRIPTIONS_EMAIL, artefact);
+
+        assertEquals(YES, personalisation.get(DISPLAY_CASE_NUMBERS), "Display case numbers is not Yes");
+        assertEquals(List.of(CASE_NUMBER_VALUE), personalisation.get(CASE_NUMBERS),
+                     "Case number not as expected"
+        );
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1295

### Change description ###

Added case name mapping to Subscription Emails.

If the user has subscribed by case number which is present in the publication, then it will try to map it to the case name.

If a case name is present, then it will display this in the email subject, and body.

![image](https://user-images.githubusercontent.com/87066931/226407968-079d490c-7818-4308-8464-b11985de9e53.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
