### PR TITLE
PUB-2134 - Fix base 64 with third parties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ dependencies {
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.11.0'
   testImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.11.0'
   testImplementation group: 'com.squareup.okhttp3', name: 'okhttp-tls', version: '4.11.0'
+  testImplementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.29'
 }
 
 mainClassName = 'uk.gov.hmcts.reform.pip.publication.services.Application'

--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/ThirdPartyManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/ThirdPartyManagementService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.pip.publication.services.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pip.model.location.Location;
@@ -71,7 +72,10 @@ public class ThirdPartyManagementService {
         if (pdf.length == 0) {
             log.warn(writeLog("Empty PDF not sent to third party"));
         } else {
-            log.info(writeLog(thirdPartyService.handlePdfThirdPartyCall(api, pdf, artefact, location)));
+            // The PDF returned from channel management is returned as Base 64.
+            // This is then decoded here before sending to third parties.
+            log.info(writeLog(thirdPartyService.handlePdfThirdPartyCall(
+                api, Base64.decodeBase64(pdf), artefact, location)));
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/ThirdPartyManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/service/ThirdPartyManagementServiceTest.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +52,7 @@ class ThirdPartyManagementServiceTest {
     @BeforeAll
     static void setup() {
         ARTEFACT.setArtefactId(RAND_UUID);
+        ARTEFACT.setLocationId(LOCATION_ID.toString());
         LOCATION.setLocationId(LOCATION_ID);
         LOCATION.setName(LOCATION_NAME);
     }
@@ -97,6 +99,9 @@ class ThirdPartyManagementServiceTest {
 
         assertEquals(SUCCESS_API_SENT, thirdPartyManagementService.handleThirdParty(subscription),
                      "Api subscription with json file should return successful referenceId.");
+
+        verify(thirdPartyService, times(1))
+            .handlePdfThirdPartyCall(API_DESTINATION, pdfInBytes, ARTEFACT, LOCATION);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2134

### Change description ###

Fix a bug where the PDF is sent over to third parties base 64 encoded, due to the return from channel management.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
