### PR TITLE
PUB-2807 - Updated limit for MI report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/publication/services/service/DataManagementService.java
@@ -36,10 +36,12 @@ public class DataManagementService {
     private String url;
 
     private final WebClient webClient;
+    private final WebClient miWebClient;
 
     @Autowired
-    public DataManagementService(WebClient webClient) {
+    public DataManagementService(WebClient webClient, WebClient miWebClient) {
         this.webClient = webClient;
+        this.miWebClient = miWebClient;
     }
 
     public Artefact getArtefact(UUID artefactId) {
@@ -120,7 +122,7 @@ public class DataManagementService {
 
     public List<PublicationMiData> getMiData() {
         try {
-            return webClient.get()
+            return miWebClient.get()
                 .uri(String.format("%s/publication/v2/mi-data", url))
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<List<PublicationMiData>>() {})

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/client/WebClientCreationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/client/WebClientCreationTest.java
@@ -24,10 +24,18 @@ class WebClientCreationTest {
     void createWebClient() {
 
         WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
-        WebClient webClient =
-            webClientConfiguration.webClient(authorizedClientManager);
+        WebClient webClient = webClientConfiguration.webClient(authorizedClientManager);
 
         assertNotNull(webClient, "WebClient has not been created successfully");
+    }
+
+    @Test
+    void createMiWebClient() {
+
+        WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
+        WebClient webClient = webClientConfiguration.miWebClient(authorizedClientManager);
+
+        assertNotNull(webClient, "MI WebClient has not been created successfully");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pip/publication/services/client/WebClientCreationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/publication/services/client/WebClientCreationTest.java
@@ -22,7 +22,6 @@ class WebClientCreationTest {
 
     @Test
     void createWebClient() {
-
         WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
         WebClient webClient = webClientConfiguration.webClient(authorizedClientManager);
 
@@ -31,7 +30,6 @@ class WebClientCreationTest {
 
     @Test
     void createMiWebClient() {
-
         WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
         WebClient webClient = webClientConfiguration.miWebClient(authorizedClientManager);
 
@@ -40,7 +38,6 @@ class WebClientCreationTest {
 
     @Test
     void createAuthorizedClientManager() {
-
         WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
         OAuth2AuthorizedClientManager clientManager =
             webClientConfiguration.authorizedClientManager(clientRegistrationRepository);
@@ -51,7 +48,6 @@ class WebClientCreationTest {
 
     @Test
     void createWebClientInsecure() {
-
         WebClientConfiguration webClientConfiguration = new WebClientConfiguration();
         WebClient webClient =
             webClientConfiguration.webClientInsecure();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2807

### Change description ###

Updated size limit for MI report when calling data management.

This will not effect other endpoints, which remain at the existing 3MB.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
